### PR TITLE
[fix] 회원 가입시 제대로 유저 정보가 저장 안되던 오류 및 로그인이 되지 않았음에도 넘어가던 오류  수정

### DIFF
--- a/src/pages/Login/components/UserInfoModal.jsx
+++ b/src/pages/Login/components/UserInfoModal.jsx
@@ -9,7 +9,9 @@ import {
   LANG_OPTIONS,
 } from '../../../shared/constants/options';
 import { useNavigate } from 'react-router-dom';
+import useCheckBJId from '../../../shared/hooks/api/useCheckBjId';
 import useCheckId from '../../../shared/hooks/api/useCheckId';
+
 import usePostUserProfile from '../hooks/api/usePostUserProfile';
 import { useUserName } from '../../../store/userStore';
 import { Form } from '../../../shared/components/Form';
@@ -43,7 +45,7 @@ const UserInfoModal = ({ isOpen, onClose }) => {
       setIsValidBaekjoonId(false);
     }
   };
-  const { refetch } = useCheckId(baekjoonId, onSuccessCallback);
+  const { refetch } = useCheckBJId(baekjoonId, onSuccessCallback);
 
   const handleClickRegister = () => {
     refetch();

--- a/src/pages/Login/index.jsx
+++ b/src/pages/Login/index.jsx
@@ -14,17 +14,6 @@ const Login = () => {
 
   const login = usePostLogin(onOpen);
 
-  // 네이버 로그인한 이후 다시 로그인페이지에서 네이버 로그인을 하려고 하면 계속 login api 가 요청된다
-  // !isOpen이 없으면 회원가입시 onOpen시 새로고침이 되면서 바로 /search로 넘어가서 프로필 모달을 못보게 됨
-  if (getAccessToken() && !isOpen) {
-    navigate('/search');
-  }
-
-  // 네이버 로그인시 페이지가 새로고침되면서 login도 새롭게 정의됌 아닌가?
-  if (login.isLoading) {
-    return <Loading />;
-  }
-
   return (
     <div className="w-full h-screen grid place-items-center">
       <UserInfoModal isOpen={isOpen} onClose={onClose} />

--- a/src/shared/hooks/api/useCheckBjId.js
+++ b/src/shared/hooks/api/useCheckBjId.js
@@ -1,0 +1,21 @@
+import { useQuery } from 'react-query';
+import { api } from '.';
+
+const useCheckBJId = (id, successCallback) => {
+    const { data, isLoading, refetch } = useQuery(
+      'checkBJId',
+      async () => {
+        const response = await api.get(`/api/validate/baekjoon?id=${id}`);
+        return response.data;
+      },
+      {
+        enabled: false,
+        onSuccess: data => {
+          successCallback(data);
+        },
+      },
+    );
+  
+    return { valid: data, isLoading, refetch };
+  };
+  export default useCheckBJId;


### PR DESCRIPTION
1. 네이버 로딩 관련이 추가된 이후 유저정보 저장 실패시에도 다음으로 넘어가는 오류가 있어 삭제. 
2. 백준 검증 로직과 유저 검증 로직을 분리